### PR TITLE
A completion can not go with no arguments.

### DIFF
--- a/nerdtree_plugin/project.vim
+++ b/nerdtree_plugin/project.vim
@@ -42,7 +42,7 @@ let g:loaded_nerdtree_project_plugin=1
 command! -nargs=1 NERDTreeProjectSave call g:NERDTreeProject.Add(<q-args>, b:NERDTree)
 command! -nargs=1 -complete=customlist,NERDTreeCompleteProjectNames NERDTreeProjectLoad call g:NERDTreeProject.Open(<q-args>)
 command! -nargs=1 -complete=customlist,NERDTreeCompleteProjectNames NERDTreeProjectRm call g:NERDTreeProject.Remove(<q-args>)
-command! -nargs=0 -complete=customlist,NERDTreeCompleteProjectNames NERDTreeProjectLoadFromCWD call g:NERDTreeProject.LoadFromCWD()
+command! -nargs=? -complete=customlist,NERDTreeCompleteProjectNames NERDTreeProjectLoadFromCWD call g:NERDTreeProject.LoadFromCWD()
 
 function! NERDTreeCompleteProjectNames(A,L,P) abort
     if empty(s:Project.All())


### PR DESCRIPTION
## Reproduce the bug

### ~/.vim/vimrc

```vimscript
call plug#begin('~/.vim/plugged')

Plug 'preservim/nerdtree'
Plug 'scrooloose/nerdtree-project-plugin'

call plug#end()
```

Open vim.

## Describe the bug

 My vim (8.2.3200) gives the following warning with the two plugins installed.

```
Error detected while processing /home/admin/.vim/plugged/nerdtree/plugin/NERD_tree.vim[229]..function nerdtree#postSourceActions[5]..script /home/admin/.vim/plugged/nerdtree-project-plugin/nerdtree_plugin/project.vim:
line   45: E1208: -complete used without -nargsPress 
```

Looking at the repo for project.vim, the existing code causes the warning.

```vimscript
command! -nargs=0 -complete=customlist,NERDTreeCompleteProjectNames NERDTreeProjectLoadFromCWD call g:NERDTreeProject.LoadFromCWD() 
```

A completion should go with at least an argument, while -nargs=0 means no arguments are allowed. Changing to –nargs=?, specifying 0 or 1 arguments are allowed, can solve the problem.